### PR TITLE
Fix file path spaces

### DIFF
--- a/pipelines/game/unreal_game_test_runner.jenkinsfile
+++ b/pipelines/game/unreal_game_test_runner.jenkinsfile
@@ -69,7 +69,7 @@ pipeline {
             }
             steps {
                 bat '''
-                    powershell -Command "(gc '%EDITOR_TARGET_PATH%') -replace '%UNOPTIMIZE_FALSE_LINE%', '%UNOPTIMIZE_TRUE_LINE%' | Out-File  %EDITOR_TARGET_PATH%"
+                    powershell -Command "(gc '%EDITOR_TARGET_PATH%') -replace '%UNOPTIMIZE_FALSE_LINE%', '%UNOPTIMIZE_TRUE_LINE%' | Out-File  '%EDITOR_TARGET_PATH%'"
                 '''
             }
         }
@@ -103,7 +103,7 @@ pipeline {
             }
             steps {
                 bat '''
-                    powershell -Command "(gc '%EDITOR_TARGET_PATH%') -replace '%UNOPTIMIZE_TRUE_LINE%', '%UNOPTIMIZE_FALSE_LINE%' | Out-File  %EDITOR_TARGET_PATH%"
+                    powershell -Command "(gc '%EDITOR_TARGET_PATH%') -replace '%UNOPTIMIZE_TRUE_LINE%', '%UNOPTIMIZE_FALSE_LINE%' | Out-File  '%EDITOR_TARGET_PATH%'"
                 '''
             }
         }

--- a/tests/run_tests.bat
+++ b/tests/run_tests.bat
@@ -7,7 +7,7 @@ call "%~dp0..\..\devops_data\config.bat"
 set Before=public bool UnoptimizedCode = false;
 set After=public bool UnoptimizedCode = true;
 set File=%SourceCodePath%\%ProjectPureName%Editor.Target.cs
-powershell -Command "(gc '%File%') -replace '%Before%', '%After%' | Out-File  %File%"
+powershell -Command "(gc '%File%') -replace '%Before%', '%After%' | Out-File  '%File%'"
 
 rem build sources
 call "%RunUATPath%" BuildCookRun ^
@@ -38,7 +38,7 @@ set ExludedSources=%RETVAL%
 
 rem clean obsolete artifacts
 del /q LastCoverageResults.log
-powershell -Command "(gc %File%) -replace '%After%', '%Before%' | Out-File  %File%"
+powershell -Command "(gc '%File%') -replace '%After%', '%Before%' | Out-File  '%File%'"
 
 rem copy test artifacts
 set TestsDir=%~dp0


### PR DESCRIPTION
Скрипт run_tests.bat не сработает при наличии пробелов в пути к файлу `%ProjectPureName%Editor.Target.cs` и отсутствии кавычек у переменной `%File%`. 
https://github.com/life-exe/devops_ue/blob/63ffa741bf49aeeac762b5bcf2950966e1ee95e9/tests/run_tests.bat#L9-L10
https://github.com/life-exe/devops_ue/blob/63ffa741bf49aeeac762b5bcf2950966e1ee95e9/tests/run_tests.bat#L41
Данный фикс проставляет недостающие кавычки переменной `%File%`.