### PR TITLE
fix the NORMALIZEPATH label call

### DIFF
--- a/tests/Utils/TestUtils.h
+++ b/tests/Utils/TestUtils.h
@@ -146,6 +146,6 @@ PropertyClass GetPropertyValueByName(ObjectClass* Obj, const FString& PropName)
 }
 
 }  // namespace Test
-}  // namespace TPS
+}  // namespace LifeExe
 
 #endif

--- a/tests/run_tests.bat
+++ b/tests/run_tests.bat
@@ -24,13 +24,13 @@ rem run code coverage
 ::set ExportType=cobertura:%ReportOutputPath%\Coverage\CodeCoverageReport.xml
 set ExportType=html:%ReportOutputPath%\Coverage\CodeCoverageReport
 
-call :NORMALIZEPATH %ProjectRoot%
+call :NORMALIZEPATH "%ProjectRoot%"
 set Module=%RETVAL%
 
-call :NORMALIZEPATH %SourceCodePath%
+call :NORMALIZEPATH "%SourceCodePath%"
 set Sources=%RETVAL%
 
-call :NORMALIZEPATH %ExludedPathForTestReport%
+call :NORMALIZEPATH "%ExludedPathForTestReport%"
 set ExludedSources=%RETVAL%
 
 "%OpenCPPCoveragePath%" --modules="%Module%" --sources="%Sources%" ^


### PR DESCRIPTION
Если в путях передаваемых метке NORMALIZEPATH есть пробелы, то значение RETVAL будет некорректно и OpenCppCoverage отработает тоже некорректно. Данный фикс решает эту проблему + небольшое косметическое улучшение.