### PR TITLE
add multiple excluded source paths support

### DIFF
--- a/setup/config.template
+++ b/setup/config.template
@@ -46,6 +46,7 @@ rem Tests
 set TestNames=
 set TestOutputLogPath=%ProjectRoot%\Build\Tests\Tests.log
 set ReportOutputPath=%ProjectRoot%\Build\Tests
-set ExludedPathForTestReport=%SourceCodePath%\%ProjectPureName%\Tests
+::To specify multiple paths for excluding sources, use the semicolon symbol ";". Example: %SourceCodePath%\%ProjectPureName%\Public\Tests;%SourceCodePath%\%ProjectPureName%\Private\Tests
+set ExludedPathsForTestReport=%SourceCodePath%\%ProjectPureName%\Tests
 set UEAutomationContentPath=%EnginePath%\Engine\Content\Automation
 set OpenCPPCoveragePath=C:\Program Files\OpenCppCoverage\OpenCppCoverage.exe

--- a/tests/run_tests.bat
+++ b/tests/run_tests.bat
@@ -30,11 +30,22 @@ set Module=%RETVAL%
 call :NORMALIZEPATH "%SourceCodePath%"
 set Sources=%RETVAL%
 
-call :NORMALIZEPATH "%ExludedPathForTestReport%"
-set ExludedSources=%RETVAL%
+set "ExcludedSources="
+set First="true"
+SETLOCAL ENABLEDELAYEDEXPANSION
+for %%i in (%ExludedPathsForTestReport%) do (
+    call :NORMALIZEPATH "%%i"
+    set PathToAdd=!RETVAL!
+    if !First!=="true" (
+      set First="false"
+      set "ExcludedSources=--excluded_sources="!PathToAdd!""
+    ) else (
+      set "ExcludedSources=!ExcludedSources! --excluded_sources="!PathToAdd!""
+    )
+)
 
 "%OpenCPPCoveragePath%" --modules="%Module%" --sources="%Sources%" ^
---excluded_sources="%ExludedSources%" --export_type="%ExportType%" -v -- %TestRunner%
+%ExcludedSources% --export_type="%ExportType%" -v -- %TestRunner%
 
 rem clean obsolete artifacts
 del /q LastCoverageResults.log


### PR DESCRIPTION
Добавляет поддержку нескольких передаваемых путей для исключения источников в OpenCppCoverage, необходимую, например, при разделении когда на Public/Private.