### PR TITLE
Update only existing files

### DIFF
--- a/githooks/hooks/pre-commit
+++ b/githooks/hooks/pre-commit
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-for file in $(git diff --staged --name-only | grep -i -E '\.(cpp|h|cs)$'); do
+for file in $(git diff --staged --name-only --diff-filter=ACMR | grep -i -E '\.(cpp|h|cs)$'); do
     echo ${file}
     clang-format -i ${file}
     git add ${file}


### PR DESCRIPTION
Skip deleted files, otherwise pre-commit hook fails when trying to apply clang-format to deleted file