### PR TITLE
Add Doxygen functionality on Linux GitHub Workflow

### DIFF
--- a/docs/replace-path-backslashes.py
+++ b/docs/replace-path-backslashes.py
@@ -1,0 +1,45 @@
+# This script is designed to replace back slashes ("\") with forward slashes ("/") in file paths in a Doxygen config file (Doxyfile).
+# Back slashes are used in Windows paths, while forward slashes are used in Linux paths.
+# Use this script if you are running Doxygen on a Linux system.
+
+# Usage: python replace-backslashes.py <file_to_process>
+# Example of usage:
+# py replace-path-backslashes.py Doxyfile
+
+# Example of usage in GitHub Workflow:
+#      - name: Replace back slashes
+#        run: |
+#          py devops_ue/docs/replace-path-backslashes.py devops_data/Doxyfile
+#        working-directory: ${{ github.workspace }}
+
+import sys
+import os
+import re
+
+def process_line(line):
+    # Check if the line is a comment
+    if line.startswith('#'):
+        return line
+    
+    # Replace "\" with "/" except in specified cases
+    line = re.sub(r'(?<!\\)\\(?!["\s]|$)', '/', line)
+    line = re.sub(r'(?<=\S)\\(?=\s|$)', '/', line)
+    return line
+
+def process_file(file_path):
+    with open(file_path, 'r') as file:
+        lines = file.readlines()
+
+    with open(file_path, 'w') as file:
+        for line in lines:
+            file.write(process_line(line))
+
+if __name__ == "__main__": 
+    if len(sys.argv) != 2: 
+        print("Expected usage: python replace-backslashes.py <file_to_process>")
+        sys.exit(1)
+
+    file_path = sys.argv[1]
+    # Construct the absolute path based on the current working directory
+    file_path = os.path.abspath(file_path)
+    process_file(file_path)

--- a/github_workflows/workflows/doxygen-linux.yml
+++ b/github_workflows/workflows/doxygen-linux.yml
@@ -1,0 +1,85 @@
+## Uncomment/add the branches to run this Workflow on them
+name: Game Documentation (Linux workflow)
+on:
+  push:
+    branches: 
+    #- main
+    - not-existing-branch
+  pull_request:
+    branches: 
+    #- main
+    - not-existing-branch
+
+## This is for deploy-pages
+permissions:
+  pages: write
+  deployments: write
+  id-token: write
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+
+    ## This is for deploy-pages
+    environment:
+     name: github-pages
+     url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Check Installed Software
+        run: |
+          python --version
+          pip --version
+          git --version
+
+      - name: Determine Python path
+        id: find_python_path
+        run: |
+          # Find the path to Python executable
+          PYTHON_EXEC=$(command -v python)
+          echo "PYTHON_EXEC=$PYTHON_EXEC" >> $GITHUB_ENV
+
+      ## py command is used in Doxyfile tags
+      - name: Create symbolic link for py command
+        run: |
+          # Create symbolic link named "py" pointing to Python executable
+          sudo ln -s $PYTHON_EXEC /usr/bin/py
+
+      - name: Verify py command
+        run: |
+          # Verify py command by checking its version
+          py --version
+          
+      - name: Checkout
+        uses: actions/checkout@v4
+        with: 
+          submodules: 'recursive'
+
+      - name: Install Doxygen
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y doxygen
+
+      - name: Verify Doxygen installation
+        run: doxygen --version
+
+      ## Path tags in Doxyfile must have forward slashes on Linux
+      - name: Replace back slashes
+        run: |
+          py devops_ue/docs/replace-path-backslashes.py devops_data/Doxyfile
+        working-directory: ${{ github.workspace }}
+
+      - name: Run Doxygen
+        run: doxygen devops_data/Doxyfile
+        
+      - name: Upload Docs to GitHub Pages
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: Documentation/html
+
+      - name: Setup GitHub Pages
+        uses: actions/configure-pages@v4
+        
+      - name: Deploy To GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This pull request adds functionality for generating code documentation with Doxygen and publishing it on GitHub Pages using **Linux** GitHub Workflows.

To utilize this feature, you'll need to specify branches in the _doxygen-linux.yml_ file.

There are a couple of peculiarities when running Doxygen on **Linux** that I've addressed:
- Paths in Doxygen configuration file (Doxyfile) must be specified using forward slashes, whereas they're originally represented with backslashes. To handle this, I've included the _replace-path-backslashes.py_ script, which is executed within a Linux GitHub Workflow to convert backslashes to forward slashes.
- By default, Python scripts cannot be called using the _py_ command on Linux GitHub-hosted virtual machines. This poses an issue because the _py_ command is utilized within the Doxyfile, such as INPUT_FILTER tag. To resolve this, a symbolic link is created during the Linux GitHub Workflow.

I've tested this functionality on my repository. Please review and merge it if appropriate.