### PR TITLE
Specify WITH_AUTOMATION_TESTS in PREDEFINED tag in Doxyfile

### DIFF
--- a/setup/Doxyfile.template
+++ b/setup/Doxyfile.template
@@ -2280,7 +2280,7 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             =
+PREDEFINED             = WITH_AUTOMATION_TESTS
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The


### PR DESCRIPTION
This pull request allows Doxygen generate documentation from code within WITH_AUTOMATION_TESTS conditional block, e.g. as it is used in **TestUtils.h**: 
`#if WITH_AUTOMATION_TESTS`
![image](https://github.com/life-exe/devops_ue/assets/98290889/e1c8462a-55a3-483e-9129-a062282d7943)

Also, see the connected pull request: #17 