### PR TITLE
Add default initialization to USTRUCT primitives in InputRecordingUti…

### DIFF
--- a/tests/Utils/InputRecordingUtils.h
+++ b/tests/Utils/InputRecordingUtils.h
@@ -5,56 +5,68 @@
 #include "CoreMinimal.h"
 #include "InputRecordingUtils.generated.h"
 
+/**
+ * @brief Struct representing axis data.
+ */
 USTRUCT()
 struct FAxisData
 {
     GENERATED_BODY()
 
     UPROPERTY()
-    FName Name;
+    FName Name; /**< The name of the axis. */
 
     UPROPERTY()
-    float Value;
+    float Value = 0.0f; /**< The value of the axis. */
 };
 
+/**
+ * @brief Struct representing action data.
+ */
 USTRUCT()
 struct FActionData
 {
     GENERATED_BODY()
 
     UPROPERTY()
-    FName Name;
+    FName Name; /**< The name of the action. */
 
     UPROPERTY()
-    FKey Key;
+    FKey Key; /**< The key associated with the action. */
 
     UPROPERTY()
-    bool State;
+    bool State = false; /**< The state of the action. */
 };
 
+/**
+ * @brief Struct representing input bindings data.
+ */
 USTRUCT()
 struct FBindingsData
 {
     GENERATED_BODY()
 
     UPROPERTY()
-    TArray<FAxisData> AxisValues;
+    TArray<FAxisData> AxisValues; /**< The array of axis values. */
 
     UPROPERTY()
-    TArray<FActionData> ActionValues;
+    TArray<FActionData> ActionValues; /**< The array of action values. */
 
     UPROPERTY()
-    float WorldTime{0.0f};
+    float WorldTime = 0.0f; /**< The world time. */
 };
 
+/**
+ * @brief Struct representing input data.
+ */
 USTRUCT()
 struct FInputData
 {
     GENERATED_BODY()
 
     UPROPERTY()
-    TArray<FBindingsData> Bindings;
+    TArray<FBindingsData> Bindings; /**< The array of input bindings data. */
 
     UPROPERTY()
-    FTransform InitialTransform;
+    FTransform InitialTransform; /**< The initial transform. */
 };


### PR DESCRIPTION
This fix adds default initialization to USTRUCT fields containing primitive types.

_Explanation:_

When using InputRecordingUtils.h inside a module (according the video [09. Snake game](https://www.youtube.com/watch?v=C8cXi47MB6s&list=PL2XQZYeh2Hh-1p7TqtOJhU-fiBXg_VaNX&index=10&t=3418s)), there are errors displaying in the UnrealEngine log when running Unreal Editor under debugger in VS. 

Errors example:
![image](https://github.com/life-exe/devops_ue/assets/98290889/682b12cb-92fc-4bcc-952c-389061ad3d60)

If I understand correctly, UE requires primitive types in USTRUCT fields be initialized by default.


I've found **other cases** discussing similar issues:
- https://forums.unrealengine.com/t/unreal-structs-initialization/495272
- https://github.com/CesiumGS/cesium-unreal/issues/846

Please note that **this pull request also includes inline comments** which are added with pull request #17 

_Software used:_
UE Version: 5.3.2
Microsoft Visual Studio Community 2022 (64-bit) Version 17.9.4