### PR TITLE
Add feature: Inform users about CppCoverage exclude path when creating tests files, and fix typo in Exlude

### DIFF
--- a/setup/config.template
+++ b/setup/config.template
@@ -46,6 +46,6 @@ rem Tests
 set TestNames=
 set TestOutputLogPath=%ProjectRoot%\Build\Tests\Tests.log
 set ReportOutputPath=%ProjectRoot%\Build\Tests
-set ExludedPathForTestReport=%SourceCodePath%\%ProjectPureName%\Tests
+set ExcludedPathForTestReport=%SourceCodePath%\%ProjectPureName%\Tests
 set UEAutomationContentPath=%EnginePath%\Engine\Content\Automation
 set OpenCPPCoveragePath=C:\Program Files\OpenCppCoverage\OpenCppCoverage.exe

--- a/setup/config.template
+++ b/setup/config.template
@@ -46,6 +46,7 @@ rem Tests
 set TestNames=
 set TestOutputLogPath=%ProjectRoot%\Build\Tests\Tests.log
 set ReportOutputPath=%ProjectRoot%\Build\Tests
-set ExcludedPathForTestReport=%SourceCodePath%\%ProjectPureName%\Tests
+set RelativePathToTests=Tests
+set ExcludedPathForTestReport=%SourceCodePath%\%ProjectPureName%\%RelativePathToTests%
 set UEAutomationContentPath=%EnginePath%\Engine\Content\Automation
 set OpenCPPCoveragePath=C:\Program Files\OpenCppCoverage\OpenCppCoverage.exe

--- a/tests/create_spec_file.bat
+++ b/tests/create_spec_file.bat
@@ -6,7 +6,10 @@ call "%~dp0..\..\devops_data\config.bat"
 :begin
 set /p TestClassName= "Enter test class name (without word 'Test' in the name) :"
 if [%TestClassName%]==[] goto:begin
-set /p TestRelativePath= "Enter relative to [Source\%ProjectPureName%] directory (use \ symbol for subdirs):"
+
+rem Setting TestRelativePath
+call set_TestRelativePath.bat
+if "%RETURNED_VALUE%"=="EXIT" goto:EOF
 
 rem '.spec.cpp' file name
 set TestCppFileName=%TestClassName%.spec.cpp
@@ -20,6 +23,10 @@ rem Confirmation
 echo.
 echo =========== File to be created: ===========
 echo %TestCppFilePath%
+echo.
+echo =========== FYI: Path to be excluded from OpenCppCoverage report: ===========
+echo %ExcludedPathForTestReport%*
+echo.
 echo ======================================
 echo.
 set /p UserConfirmed= "Confirm? [Y/N or (E)xit] :" 

--- a/tests/create_test_file.bat
+++ b/tests/create_test_file.bat
@@ -6,7 +6,10 @@ call "%~dp0..\..\devops_data\config.bat"
 :begin
 set /p TestClassName= "Enter test class name :"
 if [%TestClassName%]==[] goto:begin
-set /p TestRelativePath= "Enter relative to [Source\%ProjectPureName%] directory (use \ symbol for subdirs):"
+
+rem Setting TestRelativePath
+call set_TestRelativePath.bat
+if "%RETURNED_VALUE%"=="EXIT" goto:EOF
 
 rem .h / .cpp file names
 set TestCppFileName=%TestClassName%.cpp
@@ -23,6 +26,10 @@ echo.
 echo =========== Files to be created: ===========
 echo %TestCppFilePath%
 echo %TestHFilePath%
+echo.
+echo =========== FYI: Path to be excluded from OpenCppCoverage report: ===========
+echo %ExcludedPathForTestReport%*
+echo.
 echo ======================================
 echo.
 set /p UserConfirmed= "Confirm? [Y/N or (E)xit] :" 

--- a/tests/run_tests.bat
+++ b/tests/run_tests.bat
@@ -30,11 +30,11 @@ set Module=%RETVAL%
 call :NORMALIZEPATH "%SourceCodePath%"
 set Sources=%RETVAL%
 
-call :NORMALIZEPATH "%ExludedPathForTestReport%"
-set ExludedSources=%RETVAL%
+call :NORMALIZEPATH "%ExcludedPathForTestReport%"
+set ExcludedSources=%RETVAL%
 
 "%OpenCPPCoveragePath%" --modules="%Module%" --sources="%Sources%" ^
---excluded_sources="%ExludedSources%" --export_type="%ExportType%" -v -- %TestRunner%
+--excluded_sources="%ExcludedSources%" --export_type="%ExportType%" -v -- %TestRunner%
 
 rem clean obsolete artifacts
 del /q LastCoverageResults.log

--- a/tests/set_TestRelativePath.bat
+++ b/tests/set_TestRelativePath.bat
@@ -1,0 +1,22 @@
+:: Copyright LifeEXE. All Rights Reserved.
+
+@echo off
+
+rem This script is designed to be called from create_spec_file.bat and create_test_file.bat
+rem It sets TestRelativePath (relative path for saving the test files)
+
+set TestRelativePath=%RelativePathToTests%
+echo In what directory do you want to create the test file(s)? The target directory relative to [Source\%ProjectPureName%] is currently "%TestRelativePath%".
+echo Please note that OpenCppCoverage will exclude tests from the following path: [%ExcludedPathForTestReport%*]. 
+:change_TestRelativePath
+set /p ChangeDirChoice= "Do you want to change the target directory? [Y/N or (E)xit] :"
+if /i "%ChangeDirChoice%"=="Y" (
+	set /p TestRelativePath= "Enter the new relative to [Source\%ProjectPureName%] directory (use \ symbol for subdirs) :"
+) else if /i "%ChangeDirChoice%"=="e" (
+	set RETURNED_VALUE=EXIT
+) else if /i "%ChangeDirChoice%"=="n" (
+	 rem Just continue with the current TestRelativePath
+) else (
+    echo Invalid ChangeDirChoice. Please enter Y, N or E.
+	goto change_TestRelativePath
+)


### PR DESCRIPTION
This pull request improves functionality of creating test files. Also it fixes typos in variable names containing _Exluded_

**Previous behavior:**

The directory with test files which are to be excluded from OpenCppCoverage report is  hard-coded in _config.bat_ as `\Tests` (which means that the directories starting with "Tests" are excluded from code coverage report, e.g. directories such as `Tests`, `Tests123`, `Tests\123\` etc are excluded). 

**Problem:**

However, using scripts _create_spec_file.bat_ and _create_test_file.bat_ users can create test files in any directory (e.g. `MyTests`). If this new directory does not match `Tests*` pattern, it will be not excluded from the code coverage report. This is not desired behavior. 

**New behavior:**

Functionality added with this pull request informs users about what path will be excluded from OpenCppCoverage report when the users create tests files. This information will remind users that test files should be created in the specified path.

**Example of updated output in create_spec_file.bat:**
![image](https://github.com/life-exe/devops_ue/assets/98290889/37a5c5bf-e918-4414-b60d-6fde05afe740)

**Typos fix:**
This pull request also fixes the typos in the variable names because these variables are used in the added functionality: 
"c" is missing in variable names starting with "Exluded..." (should be "Excluded...")

